### PR TITLE
Replace each() function in xmlrpc.inc

### DIFF
--- a/Infusionsoft/xmlrpc.inc
+++ b/Infusionsoft/xmlrpc.inc
@@ -3097,7 +3097,8 @@ class xmlrpcval
         //if (is_object($o) && (get_class($o) == 'xmlrpcval' || is_subclass_of($o, 'xmlrpcval')))
         //{
         reset($this->me);
-        list($typ, $val) = each($this->me);
+        $typ = key($this->me);
+        $val = current($this->me);
         return '<value>' . $this->serializedata($typ, $val, $charset_encoding) . "</value>\n";
         //}
     }


### PR DESCRIPTION
The each() function is [deprecated since PHP 7.2](https://www.php.net/manual/en/function.each.php).